### PR TITLE
Initial release of django-pgbulk.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,29 @@
 django-pgbulk
-########################################################################
+#############
+
+``django-pgplus``, forked from
+`django-manager-utils <https://django-manager-utils.readthedocs.io>`__,
+provides several optimized bulk operations for Postgres:
+
+1. ``update`` - For updating a list of models in bulk. Although Django
+   provides a ``bulk_update`` in 2.2, it performs individual updates for
+   every row and does not perform a native bulk update.
+2. ``upsert`` - For doing a bulk update or insert. This function uses
+   postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
+   operation. There are several options to this function that allow the
+   user to avoid touching rows if they result in a duplicate update, along
+   with returning which rows were updated, created, or untouched.
+3. ``sync`` - For syncing a list of models with a table. Does a bulk
+   upsert and also deletes any rows in the source queryset that were not
+   part of the input data.
+
+For more examples, see the
+`django-pgbulk docs <https://django-pgbulk.readthedocs.io/>`_.
 
 Documentation
 =============
 
-`View the django-pgbulk docs here
-<https://django-pgbulk.readthedocs.io/>`_.
+`View the django-pgbulk docs here <https://django-pgbulk.readthedocs.io/>`_.
 
 Installation
 ============
@@ -22,3 +40,8 @@ Contributing Guide
 
 For information on setting up django-pgbulk for development and
 contributing changes, view `CONTRIBUTING.rst <CONTRIBUTING.rst>`_.
+
+Primary Authors
+===============
+
+- @wesleykendall (Wes Kendall)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,33 @@
 django-pgbulk
-=======================================================================
+=============
 
-Welcome to the docs for django-pgbulk! It doesn't appear that
-the author has created any Sphinx docs for their project yet. Try
-viewing the `README <https://github.com/jyveapp/django-pgbulk>`_
-of their project for documentation.
+``django-pgplus``, forked from
+`django-manager-utils <https://django-manager-utils.readthedocs.io>`__,
+provides several optimized bulk operations for Postgres:
+
+1. `pgbulk.update` - For updating a list of models in bulk. Although Django
+   provides a ``bulk_update`` in 2.2, it performs individual updates for
+   every row and does not perform a native bulk update.
+2. `pgbulk.upsert` - For doing a bulk update or insert. This function uses
+   postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
+   operation. There are several options to this function that allow the
+   user to avoid touching rows if they result in a duplicate update, along
+   with returning which rows were updated, created, or untouched.
+3. `pgbulk.sync` - For syncing a list of models with a table. Does a bulk
+   upsert and also deletes any rows in the source queryset that were not
+   part of the input data.
+
+
+pgbulk.update
+-------------
+.. autofunction:: pgbulk.update
+
+
+pgbulk.upsert
+-------------
+.. autofunction:: pgbulk.upsert
+
+
+pgbulk.sync
+-----------
+.. autofunction:: pgbulk.sync

--- a/pgbulk/__init__.py
+++ b/pgbulk/__init__.py
@@ -1,0 +1,6 @@
+from pgbulk.core import sync
+from pgbulk.core import update
+from pgbulk.core import upsert
+
+
+__all__ = ['update', 'upsert', 'sync']

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -1,0 +1,720 @@
+from collections import namedtuple
+import itertools
+
+from django.db import connections
+from django.db import models
+from django.utils import timezone
+
+
+class UpsertResult(list):
+    """
+    Returned by the upsert operation.
+
+    Wraps a list and provides properties to access created, updated,
+    untouched, and deleted elements
+    """
+
+    @property
+    def created(self):
+        return (i for i in self if i.status_ == 'c')
+
+    @property
+    def updated(self):
+        return (i for i in self if i.status_ == 'u')
+
+    @property
+    def untouched(self):
+        return (i for i in self if i.status_ == 'n')
+
+    @property
+    def deleted(self):
+        return (i for i in self if i.status_ == 'd')
+
+
+def _quote(field):
+    return '"{0}"'.format(field)
+
+
+def _get_update_fields(queryset, to_update, exclude=None):
+    """
+    Get the fields to be updated in an upsert.
+
+    Always exclude auto_now_add, auto_created fields, and unique fields in an
+    update
+    """
+    exclude = exclude or []
+    model = queryset.model
+    fields = {
+        **{field.attname: field for field in model._meta.fields},
+        **{field.name: field for field in model._meta.fields},
+    }
+
+    if to_update is None:
+        to_update = [field.attname for field in model._meta.fields]
+
+    to_update = [
+        attname
+        for attname in to_update
+        if (
+            attname not in exclude
+            and not getattr(fields[attname], 'auto_now_add', False)
+            and not fields[attname].auto_created
+        )
+    ]
+
+    return to_update
+
+
+def _fill_auto_fields(queryset, values):
+    """
+    Given a list of models, fill in auto_now and auto_now_add fields
+    for upserts. Since django manager utils passes Django's ORM, these values
+    have to be automatically constructed
+    """
+    model = queryset.model
+    auto_field_names = [
+        f.attname
+        for f in model._meta.fields
+        if getattr(f, 'auto_now', False) or getattr(f, 'auto_now_add', False)
+    ]
+    now = timezone.now()
+    for value in values:
+        for f in auto_field_names:
+            setattr(value, f, now)
+
+    return values
+
+
+def _sort_by_unique_fields(queryset, model_objs, unique_fields):
+    """
+    Sort a list of models by their unique fields.
+
+    Sorting models in an upsert greatly reduces the chances of deadlock
+    when doing concurrent upserts
+    """
+    model = queryset.model
+    connection = connections[queryset.db]
+    unique_fields = [
+        field for field in model._meta.fields if field.attname in unique_fields
+    ]
+
+    def sort_key(model_obj):
+        return tuple(
+            field.get_db_prep_save(
+                getattr(model_obj, field.attname), connection
+            )
+            for field in unique_fields
+        )
+
+    return sorted(model_objs, key=sort_key)
+
+
+def _get_values_for_row(queryset, model_obj, all_fields):
+    connection = connections[queryset.db]
+    return [
+        # Convert field value to db value
+        # Use attname here to support fields with custom db_column names
+        field.get_db_prep_save(getattr(model_obj, field.attname), connection)
+        for field in all_fields
+    ]
+
+
+def _get_values_for_rows(queryset, model_objs, all_fields):
+    connection = connections[queryset.db]
+    row_values = []
+    sql_args = []
+
+    for i, model_obj in enumerate(model_objs):
+        sql_args.extend(_get_values_for_row(queryset, model_obj, all_fields))
+        if i == 0:
+            row_values.append(
+                '({0})'.format(
+                    ', '.join(
+                        [
+                            '%s::{0}'.format(f.db_type(connection))
+                            for f in all_fields
+                        ]
+                    )
+                )
+            )
+        else:
+            row_values.append(
+                '({0})'.format(', '.join(['%s'] * len(all_fields)))
+            )
+
+    return row_values, sql_args
+
+
+def _get_return_fields_sql(returning, return_status=False, alias=None):
+    if alias:
+        return_fields_sql = ', '.join(
+            '{0}.{1}'.format(alias, _quote(field)) for field in returning
+        )
+    else:
+        return_fields_sql = ', '.join(_quote(field) for field in returning)
+
+    if return_status:
+        return_fields_sql += (
+            ', CASE WHEN xmax = 0 THEN \'c\' ELSE \'u\' END AS status_'
+        )
+
+    return return_fields_sql
+
+
+def _get_upsert_sql(
+    queryset,
+    model_objs,
+    unique_fields,
+    update_fields,
+    returning,
+    ignore_duplicate_updates=True,
+    return_untouched=False,
+):
+    """
+    Generates the postgres specific sql necessary to perform an upsert
+    (ON CONFLICT) INSERT INTO table_name (field1, field2)
+    VALUES (1, 'two')
+    ON CONFLICT (unique_field) DO UPDATE SET field2 = EXCLUDED.field2;
+    """
+    model = queryset.model
+
+    # Use all fields except pk unless the uniqueness constraint is the pk field
+    all_fields = [
+        field
+        for field in model._meta.fields
+        if field.column != model._meta.pk.name or not field.auto_created
+    ]
+
+    all_field_names = [field.column for field in all_fields]
+    returning = (
+        returning
+        if returning is not True
+        else [f.column for f in model._meta.fields]
+    )
+    all_field_names_sql = ', '.join(
+        [_quote(field) for field in all_field_names]
+    )
+
+    # Convert field names to db column names
+    unique_fields = [
+        model._meta.get_field(unique_field) for unique_field in unique_fields
+    ]
+    update_fields = [
+        model._meta.get_field(update_field) for update_field in update_fields
+    ]
+
+    unique_field_names_sql = ', '.join(
+        [_quote(field.column) for field in unique_fields]
+    )
+    update_fields_sql = ', '.join(
+        [
+            '{0} = EXCLUDED.{0}'.format(_quote(field.column))
+            for field in update_fields
+        ]
+    )
+
+    row_values, sql_args = _get_values_for_rows(
+        queryset, model_objs, all_fields
+    )
+
+    return_sql = (
+        'RETURNING ' + _get_return_fields_sql(returning, return_status=True)
+        if returning
+        else ''
+    )
+    ignore_duplicates_sql = ''
+    if ignore_duplicate_updates:
+        ignore_duplicates_sql = (
+            ' WHERE ({update_fields_sql}) IS DISTINCT FROM ({excluded_update_fields_sql}) '
+        ).format(
+            update_fields_sql=', '.join(
+                '{0}.{1}'.format(model._meta.db_table, _quote(field.column))
+                for field in update_fields
+            ),
+            excluded_update_fields_sql=', '.join(
+                'EXCLUDED.' + _quote(field.column) for field in update_fields
+            ),
+        )
+
+    on_conflict = (
+        'DO UPDATE SET {0} {1}'.format(
+            update_fields_sql, ignore_duplicates_sql
+        )
+        if update_fields
+        else 'DO NOTHING'
+    )
+
+    if return_untouched:
+        row_values_sql = ', '.join(
+            [
+                '(\'{0}\', {1})'.format(i, row_value[1:-1])
+                for i, row_value in enumerate(row_values)
+            ]
+        )
+        sql = (
+            ' WITH input_rows("temp_id_", {all_field_names_sql}) AS ('
+            '     VALUES {row_values_sql}'
+            ' ), ins AS ( '
+            '     INSERT INTO {table_name} ({all_field_names_sql})'
+            '     SELECT {all_field_names_sql} FROM input_rows ORDER BY temp_id_'
+            '     ON CONFLICT ({unique_field_names_sql}) {on_conflict} {return_sql}'
+            ' )'
+            ' SELECT DISTINCT ON ({table_pk_name}) * FROM ('
+            '     SELECT status_, {return_fields_sql}'
+            '     FROM   ins'
+            '     UNION  ALL'
+            '     SELECT \'n\' AS status_, {aliased_return_fields_sql}'
+            '     FROM input_rows'
+            '     JOIN {table_name} c USING ({unique_field_names_sql})'
+            ' ) as results'
+            ' ORDER BY results."{table_pk_name}", CASE WHEN(status_ = \'n\') THEN 1 ELSE 0 END;'
+        ).format(
+            all_field_names_sql=all_field_names_sql,
+            row_values_sql=row_values_sql,
+            table_name=model._meta.db_table,
+            unique_field_names_sql=unique_field_names_sql,
+            on_conflict=on_conflict,
+            return_sql=return_sql,
+            table_pk_name=model._meta.pk.name,
+            return_fields_sql=_get_return_fields_sql(returning),
+            aliased_return_fields_sql=_get_return_fields_sql(
+                returning, alias='c'
+            ),
+        )
+    else:
+        row_values_sql = ', '.join(row_values)
+        sql = (
+            ' INSERT INTO {table_name} ({all_field_names_sql})'
+            ' VALUES {row_values_sql}'
+            ' ON CONFLICT ({unique_field_names_sql}) {on_conflict} {return_sql}'
+        ).format(
+            table_name=model._meta.db_table,
+            all_field_names_sql=all_field_names_sql,
+            row_values_sql=row_values_sql,
+            unique_field_names_sql=unique_field_names_sql,
+            on_conflict=on_conflict,
+            return_sql=return_sql,
+        )
+
+    return sql, sql_args
+
+
+def _fetch(
+    queryset,
+    model_objs,
+    unique_fields,
+    update_fields,
+    returning,
+    sync,
+    ignore_duplicate_updates=True,
+    return_untouched=False,
+):
+    """
+    Perfom the upsert and do an optional sync operation
+    """
+    model = queryset.model
+    connection = connections[queryset.db]
+    if (return_untouched or sync) and returning is not True:
+        returning = set(returning) if returning else set()
+        returning.add(model._meta.pk.name)
+    upserted = []
+    deleted = []
+    # We must return untouched rows when doing a sync operation
+    return_untouched = True if sync else return_untouched
+
+    if model_objs:
+        sql, sql_args = _get_upsert_sql(
+            queryset,
+            model_objs,
+            unique_fields,
+            update_fields,
+            returning,
+            ignore_duplicate_updates=ignore_duplicate_updates,
+            return_untouched=return_untouched,
+        )
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, sql_args)
+            if cursor.description:
+                nt_result = namedtuple(
+                    'Result', [col[0] for col in cursor.description]
+                )
+                upserted = [nt_result(*row) for row in cursor.fetchall()]
+
+    pk_field = model._meta.pk.name
+    if sync:
+        orig_ids = queryset.values_list(pk_field, flat=True)
+        deleted = set(orig_ids) - {getattr(r, pk_field) for r in upserted}
+        model.objects.filter(pk__in=deleted).delete()
+
+    nt_deleted_result = namedtuple(
+        'DeletedResult', [model._meta.pk.name, 'status_']
+    )
+    return UpsertResult(
+        upserted
+        + [nt_deleted_result(**{pk_field: d, 'status_': 'd'}) for d in deleted]
+    )
+
+
+def _upsert(
+    queryset,
+    model_objs,
+    unique_fields,
+    update_fields=None,
+    returning=False,
+    sync=False,
+    ignore_duplicate_updates=True,
+    return_untouched=False,
+):
+    """
+    Perform a bulk upsert on a table, optionally syncing the results.
+
+    Args:
+        queryset (Model|QuerySet): A model or a queryset that defines the
+            collection to sync
+        model_objs (List[Model]): A list of Django models to sync. All models
+            in this list will be bulk upserted and any models not in the table
+            (or queryset) will be deleted if sync=True.
+        unique_fields (List[str]): A list of fields that define the uniqueness
+            of the model. The model must have a unique constraint on these
+            fields
+        update_fields (List[str], default=None): A list of fields to update
+            whenever objects already exist. If an empty list is provided, it
+            is equivalent to doing a bulk insert on the objects that don't
+            exist. If `None`, all fields will be updated.
+        returning (bool|List[str]): If True, returns all fields. If a list,
+            only returns fields in the list
+        sync (bool, default=False): Perform a sync operation on the queryset
+        ignore_duplicate_updates (bool, default=True): Don't perform an update
+            if all columns are identical to the row in the database.
+        return_untouched (bool, default=False): When
+            ``ignore_duplicate_updates`` is ``True``, untouched rows will not
+            be returned in upsert results. Set this to ``True`` to return
+            untouched rows.
+    """
+    queryset = (
+        queryset
+        if isinstance(queryset, models.QuerySet)
+        else queryset.objects.all()
+    )
+
+    # Populate automatically generated fields in the rows like date times
+    _fill_auto_fields(queryset, model_objs)
+
+    # Sort the rows to reduce the chances of deadlock during concurrent upserts
+    model_objs = _sort_by_unique_fields(queryset, model_objs, unique_fields)
+    update_fields = _get_update_fields(
+        queryset, update_fields, exclude=unique_fields
+    )
+
+    return _fetch(
+        queryset,
+        model_objs,
+        unique_fields,
+        update_fields,
+        returning,
+        sync,
+        ignore_duplicate_updates=ignore_duplicate_updates,
+        return_untouched=return_untouched,
+    )
+
+
+def update(queryset, model_objs, update_fields=None):
+    """
+    Bulk updates a list of model objects that are already saved.
+
+    Args:
+        queryset (QuerySet): The queryset to use when bulk updating
+        model_objs (List[Model]): Model object values to use for the update
+        update_fields (List[str], default=None): A list of fields on the
+            model objects to update. If ``None``, all fields will be updated.
+
+    Example:
+        Update an attribute of multiple models in bulk::
+
+            import pgbulk
+
+            pgbulk.update(
+                MyModel,
+                [
+                    MyModel(id=1, some_attr='some_val1'),
+                    MyModel(id=2, some_attr='some_val2')
+                ],
+                # These are the fields that will be updated. If not provided,
+                # all fields will be updated
+                ['some_attr']
+            )
+    """
+    queryset = (
+        queryset
+        if isinstance(queryset, models.QuerySet)
+        else queryset.objects.all()
+    )
+    connection = connections[queryset.db]
+    model = queryset.model
+    update_fields = _get_update_fields(queryset, update_fields)
+
+    # Add the pk to the value fields so we can join during the update
+    value_fields = [model._meta.pk.attname] + update_fields
+
+    row_values = [
+        [
+            model_obj._meta.get_field(field).get_db_prep_save(
+                getattr(model_obj, model_obj._meta.get_field(field).attname),
+                connection,
+            )
+            for field in value_fields
+        ]
+        for model_obj in model_objs
+    ]
+
+    # If we do not have any values or fields to update, just return
+    if len(row_values) == 0 or len(update_fields) == 0:
+        return []
+
+    db_types = [
+        model._meta.get_field(field).db_type(connection)
+        for field in value_fields
+    ]
+
+    value_fields_sql = ', '.join(
+        '"{field}"'.format(field=model._meta.get_field(field).column)
+        for field in value_fields
+    )
+
+    update_fields_sql = ', '.join(
+        [
+            '"{field}" = "new_values"."{field}"'.format(
+                field=model._meta.get_field(field).column
+            )
+            for field in update_fields
+        ]
+    )
+
+    values_sql = ', '.join(
+        [
+            '({0})'.format(
+                ', '.join(
+                    [
+                        '%s::{0}'.format(db_types[i])
+                        if not row_number and i
+                        else '%s'
+                        for i, _ in enumerate(row)
+                    ]
+                )
+            )
+            for row_number, row in enumerate(row_values)
+        ]
+    )
+
+    update_sql = (
+        'UPDATE {table} '
+        'SET {update_fields_sql} '
+        'FROM (VALUES {values_sql}) AS new_values ({value_fields_sql}) '
+        'WHERE "{table}"."{pk_field}" = "new_values"."{pk_field}"'
+    ).format(
+        table=model._meta.db_table,
+        pk_field=model._meta.pk.column,
+        update_fields_sql=update_fields_sql,
+        values_sql=values_sql,
+        value_fields_sql=value_fields_sql,
+    )
+
+    update_sql_params = list(itertools.chain(*row_values))
+
+    with connection.cursor() as cursor:
+        return cursor.execute(update_sql, update_sql_params)
+
+
+def upsert(
+    queryset,
+    model_objs,
+    unique_fields,
+    update_fields=None,
+    returning=False,
+    ignore_duplicate_updates=True,
+    return_untouched=False,
+):
+    """
+    Perform a bulk upsert on a table.
+
+    Args:
+        queryset (Model|QuerySet): A model or a queryset that defines the
+            collection to upsert
+        model_objs (List[Model]): A list of Django models to upsert. All models
+            in this list will be bulk upserted.
+        unique_fields (List[str]): A list of fields that define the uniqueness
+            of the model. The model must have a unique constraint on these
+            fields
+        update_fields (List[str], default=None): A list of fields to update
+            whenever objects already exist. If an empty list is provided, it
+            is equivalent to doing a bulk insert on the objects that don't
+            exist. If `None`, all fields will be updated.
+        returning (bool|List[str], default=False): If True, returns all fields.
+            If a list, only returns fields in the list. If False, do not
+            return results from the upsert.
+        ignore_duplicate_updates (bool, default=True): Don't perform an update
+            if all columns are identical to the row in the database.
+        return_untouched (bool, default=False): When
+            ``ignore_duplicate_updates`` is ``True``, untouched rows will not
+            be returned in upsert results. Set this to ``True`` to return
+            untouched rows.
+
+    Examples:
+        A basic bulk upsert on a model::
+
+            import pgbulk
+
+            pgbulk.upsert(
+                MyModel,
+                [
+                    MyModel(int_field=1, some_attr='some_val1'),
+                    MyModel(int_field=2, some_attr='some_val2')
+                ],
+                # These are the fields that identify the uniqueness constraint.
+                ['int_field'],
+                # These are the fields that will be updated if the row already
+                # exists. If not provided, all fields will be updated
+                ['some_attr']
+            )
+
+        Return the results of an upsert::
+
+            results = pgbulk.upsert(
+                MyModel,
+                [
+                    MyModel(int_field=1, some_attr='some_val1'),
+                    MyModel(int_field=2, some_attr='some_val2')
+                ],
+                ['int_field'],
+                ['some_attr'],
+                # ``True`` will return all columns. One can also explicitly
+                # list which columns will be returned
+                returning=True
+            )
+
+            # Print which results were created
+            print(results.created)
+
+            # Print which results were updated.
+            # By default, if an update results in no changes, it will not
+            # be updated and will not be returned.
+            print(results.updated)
+
+        Upsert values and update rows even when the update is meaningless
+        (i.e. a duplicate update). This is turned off by default, but it
+        can be enabled in case postgres triggers or other processes
+        need to happen as a result of an update::
+
+            pgbulk.upsert(
+                MyModel,
+                [
+                    MyModel(int_field=1, some_attr='some_val1'),
+                    MyModel(int_field=2, some_attr='some_val2')
+                ],
+                ['int_field'],
+                ['some_attr'],
+                # Perform updates in the database even if it's a duplicate
+                # update.
+                ignore_duplicate_updates=False
+            )
+
+        Upsert values and ignore duplicate updates, but still return
+        the rows that were untouched by the upsert::
+
+            results = pgbulk.upsert(
+                MyModel,
+                [
+                    MyModel(int_field=1, some_attr='some_val1'),
+                    MyModel(int_field=2, some_attr='some_val2')
+                ],
+                ['int_field'],
+                ['some_attr'],
+                returning=True,
+                # Even though we don't perform an update on a duplicate,
+                # return the row that was part of the upsert but untouched
+                # This option is only meaningful when
+                # ignore_duplicate_updates=True (the default)
+                return_untouched=True,
+            )
+
+            # Print untouched rows
+            print(results.untouched)
+
+    """
+    return _upsert(
+        queryset,
+        model_objs,
+        unique_fields,
+        update_fields=update_fields,
+        returning=returning,
+        ignore_duplicate_updates=ignore_duplicate_updates,
+        return_untouched=return_untouched,
+        sync=False,
+    )
+
+
+def sync(
+    queryset,
+    model_objs,
+    unique_fields,
+    update_fields=None,
+    returning=False,
+    ignore_duplicate_updates=True,
+    return_untouched=False,
+):
+    """
+    Perform a bulk sync on a table. A sync is an upsert on a list of model
+    objects followed by a delete on the queryset whose elements were not
+    in the list of models.
+
+    Args:
+        queryset (Model|QuerySet): A model or a queryset that defines the
+            collection to sync. If a model is provided, all rows are
+            candidates for the sync operation
+        model_objs (List[Model]): A list of Django models to sync. All models
+            in this list will be bulk upserted. Any models in the queryset
+            that are not present in this list will be deleted.
+        unique_fields (List[str]): A list of fields that define the uniqueness
+            of the model. The model must have a unique constraint on these
+            fields
+        update_fields (List[str], default=None): A list of fields to update
+            whenever objects already exist. If an empty list is provided, it
+            is equivalent to doing a bulk insert on the objects that don't
+            exist. If `None`, all fields will be updated.
+        returning (bool|List[str]): If True, returns all fields. If a list,
+            only returns fields in the list
+        ignore_duplicate_updates (bool, default=True): Don't perform an update
+            if the row is a duplicate.
+
+    Examples:
+        Sync two elements to a table with three elements. The sync will
+        upsert two elements and delete the third::
+
+            # Assume the MyModel table has objects with int_field=1,2,3
+            # We will sync this table to two elements
+            results = pgbulk.sync(
+                MyModel.objects.all(),
+                [
+                    MyModel(int_field=1, some_attr='some_val1'),
+                    MyModel(int_field=2, some_attr='some_val2')
+                ],
+                ['int_field'],
+                ['some_attr'],
+            )
+
+            # Print created, updated, untouched, and deleted rows from the sync
+            print(results.created)
+            print(results.updated)
+            print(results.untouched)
+            print(results.deleted)
+    """
+    return _upsert(
+        queryset,
+        model_objs,
+        unique_fields,
+        update_fields=update_fields,
+        returning=returning,
+        ignore_duplicate_updates=ignore_duplicate_updates,
+        sync=True,
+    )

--- a/pgbulk/tests/models.py
+++ b/pgbulk/tests/models.py
@@ -1,0 +1,74 @@
+from django.contrib.postgres.fields import ArrayField
+from django.contrib.postgres.fields import JSONField
+from django.db import models
+from timezone_field import TimeZoneField
+
+
+class TestModel(models.Model):
+    """
+    A model for testing manager utils.
+    """
+
+    int_field = models.IntegerField(null=True, unique=True)
+    char_field = models.CharField(max_length=128, null=True)
+    float_field = models.FloatField(null=True)
+    json_field = JSONField(default=dict)
+    array_field = ArrayField(models.CharField(max_length=128), default=list)
+    time_zone = TimeZoneField(default='UTC')
+
+    class Meta:
+        unique_together = ('int_field', 'char_field')
+
+
+class TestUniqueTzModel(models.Model):
+    """
+    A model for testing manager utils with a timezone field as the uniqueness
+    constraint.
+    """
+
+    int_field = models.IntegerField(null=True, unique=True)
+    char_field = models.CharField(max_length=128, null=True)
+    float_field = models.FloatField(null=True)
+    time_zone = TimeZoneField(unique=True)
+
+    class Meta:
+        unique_together = ('int_field', 'char_field')
+
+
+class TestAutoDateTimeModel(models.Model):
+    """
+    A model to test that upserts work with auto_now and auto_now_add
+    """
+
+    int_field = models.IntegerField(unique=True)
+    auto_now_field = models.DateTimeField(auto_now=True)
+    auto_now_add_field = models.DateTimeField(auto_now_add=True)
+
+
+class TestForeignKeyModel(models.Model):
+    """
+    A test model that has a foreign key.
+    """
+
+    int_field = models.IntegerField()
+    test_model = models.ForeignKey(TestModel, on_delete=models.CASCADE)
+
+
+class TestPkForeignKey(models.Model):
+    """
+    A test model with a primary key thats a foreign key to another model.
+    """
+
+    my_key = models.ForeignKey(
+        TestModel, primary_key=True, on_delete=models.CASCADE
+    )
+    char_field = models.CharField(max_length=128, null=True)
+
+
+class TestPkChar(models.Model):
+    """
+    A test model with a primary key that is a char field.
+    """
+
+    my_key = models.CharField(max_length=128, primary_key=True)
+    char_field = models.CharField(max_length=128, null=True)

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -1,0 +1,1220 @@
+import datetime as dt
+
+import ddf
+import freezegun
+import pytest
+from pytz import timezone
+
+import pgbulk
+from pgbulk.tests import models
+
+
+@pytest.mark.django_db
+def test_sync_w_char_pk():
+    """
+    Tests with a model that has a char pk.
+    """
+    extant_obj1 = ddf.G(models.TestPkChar, my_key='1', char_field='1')
+    extant_obj2 = ddf.G(models.TestPkChar, my_key='2', char_field='1')
+    extant_obj3 = ddf.G(models.TestPkChar, my_key='3', char_field='1')
+
+    pgbulk.sync(
+        models.TestPkChar,
+        [
+            models.TestPkChar(my_key='3', char_field='2'),
+            models.TestPkChar(my_key='4', char_field='2'),
+            models.TestPkChar(my_key='5', char_field='2'),
+        ],
+        ['my_key'],
+        ['char_field'],
+    )
+
+    assert models.TestPkChar.objects.count() == 3
+    assert models.TestPkChar.objects.filter(my_key='3').exists()
+    assert models.TestPkChar.objects.filter(my_key='4').exists()
+    assert models.TestPkChar.objects.filter(my_key='5').exists()
+
+    with pytest.raises(models.TestPkChar.DoesNotExist):
+        models.TestPkChar.objects.get(pk=extant_obj1.pk)
+    with pytest.raises(models.TestPkChar.DoesNotExist):
+        models.TestPkChar.objects.get(pk=extant_obj2.pk)
+    test_model = models.TestPkChar.objects.get(pk=extant_obj3.pk)
+    assert test_model.char_field == '2'
+
+
+@pytest.mark.django_db
+def test_sync_no_existing_objs():
+    """
+    Tests when there are no existing objects before the sync.
+    """
+    pgbulk.sync(
+        models.TestModel,
+        [
+            models.TestModel(int_field=1),
+            models.TestModel(int_field=3),
+            models.TestModel(int_field=4),
+        ],
+        ['int_field'],
+        ['float_field'],
+    )
+    assert models.TestModel.objects.count() == 3
+    assert models.TestModel.objects.filter(int_field=1).exists()
+    assert models.TestModel.objects.filter(int_field=3).exists()
+    assert models.TestModel.objects.filter(int_field=4).exists()
+
+
+@pytest.mark.django_db
+def test_sync_existing_objs_all_deleted():
+    """
+    Tests when there are existing objects that will all be deleted.
+    """
+    extant_obj1 = ddf.G(models.TestModel, int_field=1)
+    extant_obj2 = ddf.G(models.TestModel, int_field=2)
+    extant_obj3 = ddf.G(models.TestModel, int_field=3)
+
+    pgbulk.sync(
+        models.TestModel,
+        [
+            models.TestModel(int_field=4),
+            models.TestModel(int_field=5),
+            models.TestModel(int_field=6),
+        ],
+        ['int_field'],
+        ['float_field'],
+    )
+
+    assert models.TestModel.objects.count() == 3
+    assert models.TestModel.objects.filter(int_field=4).exists()
+    assert models.TestModel.objects.filter(int_field=5).exists()
+    assert models.TestModel.objects.filter(int_field=6).exists()
+
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj1.id)
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj2.id)
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj3.id)
+
+
+@pytest.mark.django_db
+def test_sync_existing_objs_all_deleted_empty_sync():
+    """
+    Tests when there are existing objects deleted because of an emtpy sync.
+    """
+    extant_obj1 = ddf.G(models.TestModel, int_field=1)
+    extant_obj2 = ddf.G(models.TestModel, int_field=2)
+    extant_obj3 = ddf.G(models.TestModel, int_field=3)
+
+    pgbulk.sync(models.TestModel, [], ['int_field'], ['float_field'])
+
+    assert not models.TestModel.objects.exists()
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj1.id)
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj2.id)
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj3.id)
+
+
+@pytest.mark.django_db
+def test_sync_existing_objs_some_deleted():
+    """
+    Tests when some existing objects will be deleted.
+    """
+    extant_obj1 = ddf.G(models.TestModel, int_field=1, float_field=1)
+    extant_obj2 = ddf.G(models.TestModel, int_field=2, float_field=1)
+    extant_obj3 = ddf.G(models.TestModel, int_field=3, float_field=1)
+
+    pgbulk.sync(
+        models.TestModel,
+        [
+            models.TestModel(int_field=3, float_field=2),
+            models.TestModel(int_field=4, float_field=2),
+            models.TestModel(int_field=5, float_field=2),
+        ],
+        ['int_field'],
+        ['float_field'],
+    )
+
+    assert models.TestModel.objects.count() == 3
+    assert models.TestModel.objects.filter(int_field=3).exists()
+    assert models.TestModel.objects.filter(int_field=4).exists()
+    assert models.TestModel.objects.filter(int_field=5).exists()
+
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj1.id)
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj2.id)
+    test_model = models.TestModel.objects.get(id=extant_obj3.id)
+    assert test_model.int_field == 3
+
+
+@pytest.mark.django_db
+def test_sync_existing_objs_some_deleted_w_queryset():
+    """
+    Tests when some existing objects will be deleted on a queryset
+    """
+    extant_obj0 = ddf.G(models.TestModel, int_field=0, float_field=1)
+    extant_obj1 = ddf.G(models.TestModel, int_field=1, float_field=1)
+    extant_obj2 = ddf.G(models.TestModel, int_field=2, float_field=1)
+    extant_obj3 = ddf.G(models.TestModel, int_field=3, float_field=1)
+    extant_obj4 = ddf.G(models.TestModel, int_field=4, float_field=0)
+
+    pgbulk.sync(
+        models.TestModel.objects.filter(int_field__lt=4),
+        [
+            models.TestModel(int_field=1, float_field=2),
+            models.TestModel(int_field=2, float_field=2),
+            models.TestModel(int_field=3, float_field=2),
+        ],
+        ['int_field'],
+        ['float_field'],
+    )
+
+    assert models.TestModel.objects.count() == 4
+    assert models.TestModel.objects.filter(int_field=1).exists()
+    assert models.TestModel.objects.filter(int_field=2).exists()
+    assert models.TestModel.objects.filter(int_field=3).exists()
+
+    with pytest.raises(models.TestModel.DoesNotExist):
+        models.TestModel.objects.get(id=extant_obj0.id)
+
+    test_model = models.TestModel.objects.get(id=extant_obj1.id)
+    assert test_model.float_field == 2
+    test_model = models.TestModel.objects.get(id=extant_obj2.id)
+    assert test_model.float_field == 2
+    test_model = models.TestModel.objects.get(id=extant_obj3.id)
+    assert test_model.float_field == 2
+    test_model = models.TestModel.objects.get(id=extant_obj4.id)
+    assert test_model.float_field == 0
+
+
+@pytest.mark.django_db
+def test_sync_existing_objs_some_deleted_wo_update():
+    """
+    Tests when some existing objects will be deleted on a queryset. Run syncing
+    with no update fields and verify they are untouched in the sync
+    """
+    objs = [
+        ddf.G(models.TestModel, int_field=i, float_field=i) for i in range(5)
+    ]
+
+    results = pgbulk.sync(
+        models.TestModel.objects.filter(int_field__lt=4),
+        [
+            models.TestModel(int_field=1, float_field=2),
+            models.TestModel(int_field=2, float_field=2),
+            models.TestModel(int_field=3, float_field=2),
+        ],
+        ['int_field'],
+        [],
+        returning=True,
+    )
+
+    assert len(list(results)) == 4
+    assert len(list(results.deleted)) == 1
+    assert len(list(results.untouched)) == 3
+    assert list(results.deleted)[0].id == objs[0].id
+
+
+@pytest.mark.django_db
+def test_sync_existing_objs_some_deleted_some_updated():
+    """
+    Tests when some existing objects will be deleted on a queryset. Run syncing
+    with some update fields.
+    """
+    objs = [
+        ddf.G(models.TestModel, int_field=i, float_field=i) for i in range(5)
+    ]
+
+    results = pgbulk.sync(
+        models.TestModel.objects.filter(int_field__lt=4),
+        [
+            models.TestModel(int_field=1, float_field=2),
+            models.TestModel(int_field=2, float_field=2),
+            models.TestModel(int_field=3, float_field=2),
+        ],
+        ['int_field'],
+        ['float_field'],
+        returning=True,
+        ignore_duplicate_updates=True,
+    )
+
+    assert len(list(results)) == 4
+    assert len(list(results.deleted)) == 1
+    assert len(list(results.updated)) == 2
+    assert len(list(results.untouched)) == 1
+    assert list(results.deleted)[0].id == objs[0].id
+
+
+@pytest.mark.django_db
+def test_upsert_return_upserts_none():
+    """
+    Tests the return_upserts flag on bulk upserts when there is no data.
+    """
+    return_values = pgbulk.upsert(
+        models.TestModel, [], ['float_field'], ['float_field'], returning=True
+    )
+    assert not return_values
+
+
+@pytest.mark.django_db
+def test_upsert_return_multi_unique_fields_not_supported():
+    """
+    The new manager utils supports returning bulk upserts when there are
+    multiple unique fields.
+    """
+    return_values = pgbulk.upsert(
+        models.TestModel,
+        [],
+        ['float_field', 'int_field'],
+        ['float_field'],
+        returning=True,
+    )
+    assert not return_values
+
+
+@pytest.mark.django_db
+def test_upsert_return_created_values():
+    """
+    Tests that values that are created are returned properly when returning
+    is True.
+    """
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=1),
+            models.TestModel(int_field=3),
+            models.TestModel(int_field=4),
+        ],
+        ['int_field'],
+        ['float_field'],
+        returning=True,
+    )
+
+    assert len(list(results.created)) == 3
+    for test_model, expected_int in zip(
+        sorted(results.created, key=lambda k: k.int_field), [1, 3, 4]
+    ):
+        assert test_model.int_field == expected_int
+        assert test_model.id is not None
+    assert models.TestModel.objects.count() == 3
+
+
+@pytest.mark.django_db
+def test_upsert_return_list_of_values():
+    """
+    Tests that values that are created are returned properly when returning
+    is True. Set returning to a list of fields
+    """
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=1, float_field=2),
+            models.TestModel(int_field=3, float_field=4),
+            models.TestModel(int_field=4, float_field=5),
+        ],
+        ['int_field'],
+        ['float_field'],
+        returning=['float_field'],
+    )
+
+    assert len(list(results.created)) == 3
+    with pytest.raises(AttributeError):
+        list(results.created)[0].int_field
+    assert {2, 4, 5} == {m.float_field for m in results.created}
+
+
+@pytest.mark.django_db
+def test_upsert_return_created_updated_values():
+    """
+    Tests returning values when the items are either updated or created.
+    """
+    # Create an item that will be updated
+    ddf.G(models.TestModel, int_field=2, float_field=1.0)
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=1, float_field=3.0),
+            models.TestModel(int_field=2.0, float_field=3.0),
+            models.TestModel(int_field=3, float_field=3.0),
+            models.TestModel(int_field=4, float_field=3.0),
+        ],
+        ['int_field'],
+        ['float_field'],
+        returning=True,
+    )
+
+    created = list(results.created)
+    updated = list(results.updated)
+    assert len(created) == 3
+    assert len(updated) == 1
+    for test_model, expected_int in zip(
+        sorted(created, key=lambda k: k.int_field), [1, 3, 4]
+    ):
+        assert test_model.int_field == expected_int
+        assert test_model.float_field == 3.0  # almostequals
+        assert test_model.id is not None
+
+    assert updated[0].int_field == 2
+    assert updated[0].float_field == 3.0  # almostequals
+    assert updated[0].id is not None
+    assert models.TestModel.objects.count() == 4
+
+
+@pytest.mark.django_db
+def test_upsert_created_updated_auto_datetime_values():
+    """
+    Tests when the items are either updated or created when auto_now
+    and auto_now_add datetime values are used
+    """
+    # Create an item that will be updated
+    with freezegun.freeze_time('2018-09-01 00:00:00'):
+        ddf.G(models.TestAutoDateTimeModel, int_field=1)
+
+    with freezegun.freeze_time('2018-09-02 00:00:00'):
+        results = pgbulk.upsert(
+            models.TestAutoDateTimeModel,
+            [
+                models.TestAutoDateTimeModel(int_field=1),
+                models.TestAutoDateTimeModel(int_field=2),
+                models.TestAutoDateTimeModel(int_field=3),
+                models.TestAutoDateTimeModel(int_field=4),
+            ],
+            ['int_field'],
+            returning=True,
+        )
+
+    assert len(list(results.created)) == 3
+    assert len(list(results.updated)) == 1
+
+    expected_auto_now = [
+        dt.datetime(2018, 9, 2),
+        dt.datetime(2018, 9, 2),
+        dt.datetime(2018, 9, 2),
+        dt.datetime(2018, 9, 2),
+    ]
+    expected_auto_now_add = [
+        dt.datetime(2018, 9, 1),
+        dt.datetime(2018, 9, 2),
+        dt.datetime(2018, 9, 2),
+        dt.datetime(2018, 9, 2),
+    ]
+    for i, test_model in enumerate(sorted(results, key=lambda k: k.int_field)):
+        assert test_model.auto_now_field == expected_auto_now[i]
+        assert test_model.auto_now_add_field == expected_auto_now_add[i]
+
+
+@pytest.mark.django_db
+def test_upsert_wo_update_fields():
+    """
+    Tests bulk_upsert with no update fields. This function in turn should
+    just do a bulk create for any models that do not already exist.
+    """
+    # Create models that already exist
+    ddf.G(models.TestModel, int_field=1, float_field=1)
+    ddf.G(models.TestModel, int_field=2, float_field=2)
+    # Perform a bulk_upsert with one new model
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=1, float_field=3),
+            models.TestModel(int_field=2, float_field=3),
+            models.TestModel(int_field=3, float_field=3),
+        ],
+        ['int_field'],
+        update_fields=[],
+    )
+    # Three objects should now exist, but no float fields should be updated
+    assert models.TestModel.objects.count() == 3
+    for test_model, expected_int_value in zip(
+        models.TestModel.objects.order_by('int_field'), [1, 2, 3]
+    ):
+        assert test_model.int_field == expected_int_value
+        assert test_model.float_field == expected_int_value
+
+
+@pytest.mark.django_db
+def test_upsert_w_blank_arguments():
+    """
+    Tests using required arguments and using blank arguments for everything
+    else.
+    """
+    pgbulk.upsert(models.TestModel, [], ['field'], ['field'])
+    assert not models.TestModel.objects.exists()
+
+
+@pytest.mark.django_db
+def test_upsert_no_updates():
+    """
+    Tests the case when no updates were previously stored (i.e objects are only
+    created)
+    """
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        ['char_field', 'float_field'],
+    )
+
+    for i, model_obj in enumerate(
+        models.TestModel.objects.order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == str(i)
+        assert model_obj.float_field == i  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_update_fields_returning():
+    """
+    Tests the case when all updates were previously stored and the int
+    field is used as a uniqueness constraint. Assert returned values are
+    expected and that it updates all fields by default
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    test_models = [
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+        for i in range(3)
+    ]
+
+    # Update using the int field as a uniqueness constraint
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        returning=True,
+    )
+
+    assert list(results.created) == []
+    assert {u.id for u in results.updated} == {t.id for t in test_models}
+    assert {u.int_field for u in results.updated} == {0, 1, 2}
+    assert {u.float_field for u in results.updated} == {0, 1, 2}
+    assert {u.char_field for u in results.updated} == {'0', '1', '2'}
+
+
+@pytest.mark.django_db
+def test_upsert_no_update_fields_returning():
+    """
+    Tests the case when all updates were previously stored and the int
+    field is used as a uniqueness constraint. This test does not update
+    any fields
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        [],
+        returning=True,
+    )
+
+    assert list(results) == []
+
+
+@pytest.mark.django_db
+def test_upsert_update_duplicate_fields_returning_none_updated():
+    """
+    Tests the case when all updates were previously stored and the upsert
+    tries to update the rows with duplicate values.
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='-1', float_field=-1),
+            models.TestModel(int_field=1, char_field='-1', float_field=-1),
+            models.TestModel(int_field=2, char_field='-1', float_field=-1),
+        ],
+        ['int_field'],
+        ['char_field', 'float_field'],
+        returning=True,
+        ignore_duplicate_updates=True,
+    )
+
+    assert list(results) == []
+
+
+@pytest.mark.django_db
+def test_upsert_update_duplicate_fields_returning_some_updated():
+    """
+    Tests the case when all updates were previously stored and the upsert
+    tries to update the rows with duplicate values. Test when some aren't
+    duplicates
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='-1', float_field=-1),
+            models.TestModel(int_field=1, char_field='-1', float_field=-1),
+            models.TestModel(int_field=2, char_field='0', float_field=-1),
+        ],
+        ['int_field'],
+        ['char_field', 'float_field'],
+        returning=['char_field'],
+        ignore_duplicate_updates=True,
+    )
+
+    assert list(results.created) == []
+    assert len(list(results.updated)) == 1
+    assert list(results.updated)[0].char_field == '0'
+
+
+@pytest.mark.django_db
+def test_upsert_update_duplicate_fields_returning_some_updated_untouched():
+    """
+    Tests the case when all updates were previously stored and the upsert
+    tries to update the rows with duplicate values. Test when some aren't
+    duplicates
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='-1', float_field=-1),
+            models.TestModel(int_field=1, char_field='-1', float_field=-1),
+            models.TestModel(int_field=2, char_field='0', float_field=-1),
+            models.TestModel(int_field=3, char_field='3', float_field=3),
+        ],
+        ['int_field'],
+        ['char_field', 'float_field'],
+        returning=['char_field'],
+        ignore_duplicate_updates=True,
+        return_untouched=True,
+    )
+
+    assert len(list(results.updated)) == 1
+    assert len(list(results.untouched)) == 2
+    assert len(list(results.created)) == 1
+    assert list(results.updated)[0].char_field == '0'
+    assert list(results.created)[0].char_field == '3'
+
+
+@pytest.mark.django_db
+def test_upsert_update_duplicate_fields_returning_some_updated_ignore_dups():
+    """
+    Tests the case when all updates were previously stored and the upsert
+    tries to update the rows with duplicate values. Test when some aren't
+    duplicates and return untouched results. There will be no untouched
+    results in this test since we turn off ignoring duplicate updates
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    results = pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='-1', float_field=-1),
+            models.TestModel(int_field=1, char_field='-1', float_field=-1),
+            models.TestModel(int_field=2, char_field='0', float_field=-1),
+            models.TestModel(int_field=3, char_field='3', float_field=3),
+        ],
+        ['int_field'],
+        ['char_field', 'float_field'],
+        returning=['char_field'],
+        ignore_duplicate_updates=False,
+        return_untouched=True,
+    )
+
+    assert len(list(results.untouched)) == 0
+    assert len(list(results.updated)) == 3
+    assert len(list(results.created)) == 1
+    assert list(results.created)[0].char_field == '3'
+
+
+@pytest.mark.django_db
+def test_upsert_all_updates_unique_int_field():
+    """
+    Tests the case when all updates were previously stored and the int
+    field is used as a uniqueness constraint.
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        ['char_field', 'float_field'],
+    )
+
+    # Verify that the fields were updated
+    assert models.TestModel.objects.count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == str(i)
+        assert model_obj.float_field == i  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_all_updates_unique_int_field_update_float_field():
+    """
+    Tests the case when all updates were previously stored and the int
+    field is used as a uniqueness constraint. Only updates the float field
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        update_fields=['float_field'],
+    )
+
+    # Verify that the float field was updated
+    assert models.TestModel.objects.count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == '-1'
+        assert model_obj.float_field == i  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_some_updates_unique_int_field_update_float_field():
+    """
+    Tests the case when some updates were previously stored and the int
+    field is used as a uniqueness constraint. Only updates the float field.
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(2):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint. The first two
+    # are updated while the third is created
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        ['float_field'],
+    )
+
+    # Verify that the float field was updated for the first two models and
+    # the char field was not updated for the first two. The char field,
+    # however, should be '2' for the third model since it was created
+    assert models.TestModel.objects.count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == '-1' if i < 2 else '2'
+        assert model_obj.float_field == i  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_some_updates_unique_timezone_field_update_float_field():
+    """
+    Tests the case when some updates were previously stored and the timezone
+    field is used as a uniqueness constraint. Only updates the float field.
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in ['US/Eastern', 'US/Central']:
+        ddf.G(
+            models.TestUniqueTzModel,
+            time_zone=i,
+            char_field='-1',
+            float_field=-1,
+        )
+
+    # Update using the int field as a uniqueness constraint. The first two
+    # are updated while the third is created
+    pgbulk.upsert(
+        models.TestUniqueTzModel,
+        [
+            models.TestModel(
+                time_zone=timezone('US/Eastern'), char_field='0', float_field=0
+            ),
+            models.TestModel(
+                time_zone=timezone('US/Central'), char_field='1', float_field=1
+            ),
+            models.TestModel(
+                time_zone=timezone('UTC'), char_field='2', float_field=2
+            ),
+        ],
+        ['time_zone'],
+        ['float_field'],
+    )
+
+    # Verify that the float field was updated for the first two models and
+    # the char field was not updated for the first two. The char field,
+    # however, should be '2' for the third model since it was created
+    m1 = models.TestUniqueTzModel.objects.get(time_zone=timezone('US/Eastern'))
+    assert m1.char_field == '-1'
+    assert m1.float_field == 0  # almostequals
+
+    m2 = models.TestUniqueTzModel.objects.get(time_zone=timezone('US/Central'))
+    assert m2.char_field == '-1'
+    assert m2.float_field == 1  # almostequals
+
+    m3 = models.TestUniqueTzModel.objects.get(time_zone=timezone('UTC'))
+    assert m3.char_field == '2'
+    assert m3.float_field == 2  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_some_updates_unique_int_char_field_update_float_field():
+    """
+    Tests the case when some updates were previously stored and the int and
+    char fields are used as a uniqueness constraint. Only updates the float
+    field.
+    """
+    # Create previously stored test models with a unique int and char field
+    for i in range(2):
+        ddf.G(models.TestModel, int_field=i, char_field=str(i), float_field=-1)
+
+    # Update using the int field as a uniqueness constraint. The first two
+    # are updated while the third is created
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=1, char_field='1', float_field=1),
+            models.TestModel(int_field=2, char_field='2', float_field=2),
+        ],
+        ['int_field', 'char_field'],
+        ['float_field'],
+    )
+
+    # Verify that the float field was updated for the first two models and
+    # the char field was not updated for the first two. The char field,
+    # however, should be '2' for the third model since it was created
+    assert models.TestModel.objects.count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == str(i)
+        assert model_obj.float_field == i  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_no_updates_unique_int_char_field():
+    """
+    Tests the case when no updates were previously stored and the int and
+    char fields are used as a uniqueness constraint. In this case, there
+    is data previously stored, but the uniqueness constraints don't match.
+    """
+    # Create previously stored test models with a unique int field and -1 for
+    # all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int and char field as a uniqueness constraint. All
+    # three objects are created
+    pgbulk.upsert(
+        models.TestModel,
+        [
+            models.TestModel(int_field=3, char_field='0', float_field=0),
+            models.TestModel(int_field=4, char_field='1', float_field=1),
+            models.TestModel(int_field=5, char_field='2', float_field=2),
+        ],
+        ['int_field', 'char_field'],
+        ['float_field'],
+    )
+
+    # Verify that no updates occured
+    assert models.TestModel.objects.count() == 6
+    assert models.TestModel.objects.filter(char_field='-1').count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.filter(char_field='-1').order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == '-1'
+        assert model_obj.float_field == -1  # almostequals
+    assert models.TestModel.objects.exclude(char_field='-1').count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.exclude(char_field='-1').order_by('int_field')
+    ):
+        assert model_obj.int_field == i + 3
+        assert model_obj.char_field == str(i)
+        assert model_obj.float_field == i  # almostequals
+
+
+@pytest.mark.django_db
+def test_upsert_some_updates_unique_int_char_field_queryset():
+    """
+    Tests the case when some updates were previously stored and a queryset
+    is used on the bulk upsert.
+    """
+    # Create previously stored test models with a unique int field and -1
+    # for all other fields
+    for i in range(3):
+        ddf.G(models.TestModel, int_field=i, char_field='-1', float_field=-1)
+
+    # Update using the int field as a uniqueness constraint on a queryset.
+    # Only one object should be updated.
+    pgbulk.upsert(
+        models.TestModel.objects.filter(int_field=0),
+        [
+            models.TestModel(int_field=0, char_field='0', float_field=0),
+            models.TestModel(int_field=4, char_field='1', float_field=1),
+            models.TestModel(int_field=5, char_field='2', float_field=2),
+        ],
+        ['int_field'],
+        ['float_field'],
+    )
+
+    # Verify that two new objecs were created
+    assert models.TestModel.objects.count() == 5
+    assert models.TestModel.objects.filter(char_field='-1').count() == 3
+    for i, model_obj in enumerate(
+        models.TestModel.objects.filter(char_field='-1').order_by('int_field')
+    ):
+        assert model_obj.int_field == i
+        assert model_obj.char_field == '-1'
+
+
+@pytest.mark.django_db
+def test_update_foreign_key_by_id():
+    t_model = ddf.G(models.TestModel)
+    t_fk_model = ddf.G(models.TestForeignKeyModel)
+    t_fk_model.test_model = t_model
+    pgbulk.update(models.TestForeignKeyModel, [t_fk_model], ['test_model_id'])
+    assert models.TestForeignKeyModel.objects.get().test_model == t_model
+
+
+@pytest.mark.django_db
+def test_update_foreign_key_by_name():
+    t_model = ddf.G(models.TestModel)
+    t_fk_model = ddf.G(models.TestForeignKeyModel)
+    t_fk_model.test_model = t_model
+    pgbulk.update(models.TestForeignKeyModel, [t_fk_model], ['test_model'])
+    assert models.TestForeignKeyModel.objects.get().test_model == t_model
+
+
+@pytest.mark.django_db
+def test_update_foreign_key_pk_using_id():
+    """
+    Tests a bulk update on a model that has a primary key to a foreign key.
+    It uses the id of the pk in the update
+    """
+    t = ddf.G(models.TestPkForeignKey, char_field='hi')
+    pgbulk.update(
+        models.TestPkForeignKey,
+        [models.TestPkForeignKey(my_key_id=t.my_key_id, char_field='hello')],
+        ['char_field'],
+    )
+    assert models.TestPkForeignKey.objects.count() == 1
+    assert models.TestPkForeignKey.objects.filter(
+        char_field='hello', my_key=t.my_key
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_update_foreign_key_pk():
+    """
+    Tests a bulk update on a model that has a primary key to a foreign key.
+    It uses the foreign key itself in the update
+    """
+    t = ddf.G(models.TestPkForeignKey, char_field='hi')
+    pgbulk.update(
+        models.TestPkForeignKey,
+        [models.TestPkForeignKey(my_key=t.my_key, char_field='hello')],
+        ['char_field'],
+    )
+    assert models.TestPkForeignKey.objects.count() == 1
+    assert models.TestPkForeignKey.objects.filter(
+        char_field='hello', my_key=t.my_key
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_update_char_pk():
+    """
+    Tests a bulk update on a model that has a primary key to a char field.
+    """
+    ddf.G(models.TestPkChar, char_field='hi', my_key='1')
+    pgbulk.update(
+        models.TestPkChar,
+        [models.TestPkChar(my_key='1', char_field='hello')],
+        ['char_field'],
+    )
+    assert models.TestPkChar.objects.count() == 1
+    assert models.TestPkChar.objects.filter(
+        char_field='hello', my_key='1'
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_update_none():
+    """
+    Tests when no values are provided to bulk update.
+    """
+    pgbulk.update(models.TestModel, [], [])
+
+
+@pytest.mark.django_db
+def test_update_no_fields_given():
+    """
+    Tests updating when no fields are given. All fields should be updated
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
+    test_obj_1.int_field = 7
+    test_obj_1.float_field = 8
+    test_obj_2.int_field = 9
+    test_obj_2.float_field = 10
+
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2])
+
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 7
+    assert test_obj_1.float_field == 8
+    assert test_obj_2.int_field == 9
+    assert test_obj_2.float_field == 10
+
+
+@pytest.mark.django_db
+def test_update_floats_to_null():
+    """
+    Tests updating a float field to a null field.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
+    test_obj_1.float_field = None
+    test_obj_2.float_field = None
+
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2], ['float_field'])
+
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.float_field is None
+    assert test_obj_2.float_field is None
+
+
+@pytest.mark.django_db
+def test_update_ints_to_null():
+    """
+    Tests updating an int field to a null field.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
+    test_obj_1.int_field = None
+    test_obj_2.int_field = None
+
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2], ['int_field'])
+
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field is None
+    assert test_obj_2.int_field is None
+
+
+@pytest.mark.django_db
+def test_update_chars_to_null():
+    """
+    Tests updating a char field to a null field.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, char_field='2')
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, char_field='3')
+    test_obj_1.char_field = None
+    test_obj_2.char_field = None
+
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2], ['char_field'])
+
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.char_field is None
+    assert test_obj_2.char_field is None
+
+
+@pytest.mark.django_db
+def test_update_objs_no_fields_to_update():
+    """
+    Tests when objects are given to bulk update with no fields to update.
+    Nothing should change in the objects.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2)
+    # Change the int fields on the models
+    test_obj_1.int_field = 3
+    test_obj_2.int_field = 4
+    # Do a bulk update with no update fields
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2], [])
+    # The test objects int fields should be untouched
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 1
+    assert test_obj_2.int_field == 2
+
+
+@pytest.mark.django_db
+def test_update_objs_one_field_to_update():
+    """
+    Tests when objects are given to bulk update with one field to update.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2)
+    # Change the int fields on the models
+    test_obj_1.int_field = 3
+    test_obj_2.int_field = 4
+    # Do a bulk update with the int fields
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2], ['int_field'])
+    # The test objects int fields should be untouched
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 3
+    assert test_obj_2.int_field == 4
+
+
+@pytest.mark.django_db
+def test_update_objs_one_field_to_update_ignore_other_field():
+    """
+    Tests when objects are given to bulk update with one field to update.
+    This test changes another field not included in the update and verifies
+    it is not updated.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=1.0)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=2.0)
+    # Change the int and float fields on the models
+    test_obj_1.int_field = 3
+    test_obj_2.int_field = 4
+    test_obj_1.float_field = 3.0
+    test_obj_2.float_field = 4.0
+    # Do a bulk update with the int fields
+    pgbulk.update(models.TestModel, [test_obj_1, test_obj_2], ['int_field'])
+    # The test objects int fields should be untouched
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 3
+    assert test_obj_2.int_field == 4
+    # The float fields should not be updated
+    assert test_obj_1.float_field == 1.0
+    assert test_obj_2.float_field == 2.0
+
+
+@pytest.mark.django_db
+def test_update_objs_two_fields_to_update():
+    """
+    Tests when objects are given to bulk update with two fields to update.
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=1.0)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=2.0)
+    # Change the int and float fields on the models
+    test_obj_1.int_field = 3
+    test_obj_2.int_field = 4
+    test_obj_1.float_field = 3.0
+    test_obj_2.float_field = 4.0
+    # Do a bulk update with the int fields
+    pgbulk.update(
+        models.TestModel,
+        [test_obj_1, test_obj_2],
+        ['int_field', 'float_field'],
+    )
+    # The test objects int fields should be untouched
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 3
+    assert test_obj_2.int_field == 4
+    # The float fields should be updated
+    assert test_obj_1.float_field == 3.0
+    assert test_obj_2.float_field == 4.0
+
+
+@pytest.mark.django_db
+def test_update_objects_with_custom_db_field_types():
+    """
+    Tests when objects are updated that have custom field types
+    """
+    test_obj_1 = ddf.G(
+        models.TestModel,
+        int_field=1,
+        float_field=1.0,
+        json_field={'test': 'test'},
+        array_field=['one', 'two'],
+    )
+    test_obj_2 = ddf.G(
+        models.TestModel,
+        int_field=2,
+        float_field=2.0,
+        json_field={'test2': 'test2'},
+        array_field=['three', 'four'],
+    )
+
+    # Change the fields on the models
+    test_obj_1.json_field = {'test': 'updated'}
+    test_obj_1.array_field = ['one', 'two', 'updated']
+
+    test_obj_2.json_field = {'test2': 'updated'}
+    test_obj_2.array_field = ['three', 'four', 'updated']
+
+    # Do a bulk update with the int fields
+    pgbulk.update(
+        models.TestModel,
+        [test_obj_1, test_obj_2],
+        ['json_field', 'array_field'],
+    )
+
+    # Refetch the objects
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+
+    # Assert that the json field was updated
+    assert test_obj_1.json_field == {'test': 'updated'}
+    assert test_obj_2.json_field == {'test2': 'updated'}
+
+    # Assert that the array field was updated
+    assert test_obj_1.array_field, ['one', 'two' == 'updated']
+    assert test_obj_2.array_field, ['three', 'four' == 'updated']

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,1539 @@
+[[package]]
+category = "dev"
+description = "A configurable sidebar-enabled Sphinx theme"
+name = "alabaster"
+optional = false
+python-versions = "*"
+version = "0.7.12"
+
+[[package]]
+category = "dev"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.4"
+
+[[package]]
+category = "dev"
+description = "Better dates & times for Python"
+name = "arrow"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.15.7"
+
+[package.dependencies]
+python-dateutil = "*"
+
+[[package]]
+category = "main"
+description = "ASGI specs, helper code, and adapters"
+name = "asgiref"
+optional = false
+python-versions = ">=3.5"
+version = "3.2.10"
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio"]
+
+[[package]]
+category = "dev"
+description = "A few extensions to pyyaml."
+name = "aspy.yaml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.3.0"
+
+[package.dependencies]
+pyyaml = "*"
+
+[[package]]
+category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+
+[[package]]
+category = "dev"
+description = "Internationalization utilities"
+name = "babel"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8.0"
+
+[package.dependencies]
+pytz = ">=2015.7"
+
+[[package]]
+category = "dev"
+description = "Ultra-lightweight pure Python package to check if a file is binary or text."
+name = "binaryornot"
+optional = false
+python-versions = "*"
+version = "0.4.4"
+
+[package.dependencies]
+chardet = ">=3.0.2"
+
+[[package]]
+category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "19.10b0"
+
+[package.dependencies]
+appdirs = "*"
+attrs = ">=18.1.0"
+click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
+toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
+
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+category = "dev"
+description = "The AWS SDK for Python"
+name = "boto3"
+optional = false
+python-versions = "*"
+version = "1.9.243"
+
+[package.dependencies]
+botocore = ">=1.12.243,<1.13.0"
+jmespath = ">=0.7.1,<1.0.0"
+s3transfer = ">=0.2.0,<0.3.0"
+
+[[package]]
+category = "dev"
+description = "Low-level, data-driven core of boto 3."
+name = "botocore"
+optional = false
+python-versions = "*"
+version = "1.12.253"
+
+[package.dependencies]
+docutils = ">=0.10,<0.16"
+jmespath = ">=0.7.1,<1.0.0"
+
+[package.dependencies.python-dateutil]
+python = ">=2.7"
+version = ">=2.1,<3.0.0"
+
+[package.dependencies.urllib3]
+python = ">=3.4"
+version = ">=1.20,<1.26"
+
+[[package]]
+category = "dev"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2020.6.20"
+
+[[package]]
+category = "dev"
+description = "Validate configuration and produce human readable error messages."
+name = "cfgv"
+optional = false
+python-versions = ">=3.6"
+version = "3.0.0"
+
+[[package]]
+category = "dev"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "dev"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+name = "colorama"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
+
+[[package]]
+category = "dev"
+description = "A command-line utility that creates projects from project templates, e.g. creating a Python package project from a Python package project template."
+name = "cookiecutter"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.7.2"
+
+[package.dependencies]
+Jinja2 = "<3.0.0"
+MarkupSafe = "<2.0.0"
+binaryornot = ">=0.4.4"
+click = ">=7.0"
+jinja2-time = ">=0.2.0"
+poyo = ">=0.5.0"
+python-slugify = ">=4.0.0"
+requests = ">=2.23.0"
+six = ">=1.10"
+
+[[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.1"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
+category = "dev"
+description = "Distribution utilities"
+name = "distlib"
+optional = false
+python-versions = "*"
+version = "0.3.0"
+
+[[package]]
+category = "dev"
+description = "Use Database URLs in your Django Application."
+name = "dj-database-url"
+optional = false
+python-versions = "*"
+version = "0.5.0"
+
+[[package]]
+category = "main"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+name = "django"
+optional = false
+python-versions = ">=3.6"
+version = "3.0.7"
+
+[package.dependencies]
+asgiref = ">=3.2,<4.0"
+pytz = "*"
+sqlparse = ">=0.2.2"
+
+[package.extras]
+argon2 = ["argon2-cffi (>=16.1.0)"]
+bcrypt = ["bcrypt"]
+
+[[package]]
+category = "dev"
+description = "A full library to create dynamic model instances for testing purposes."
+name = "django-dynamic-fixture"
+optional = false
+python-versions = "*"
+version = "3.1.0"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+category = "dev"
+description = "A Django app providing database and form fields for pytz timezone objects."
+name = "django-timezone-field"
+optional = false
+python-versions = ">=3.5"
+version = "4.0"
+
+[package.dependencies]
+django = ">=2.2"
+pytz = "*"
+
+[[package]]
+category = "dev"
+description = "Docutils -- Python Documentation Utilities"
+name = "docutils"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.15.2"
+
+[[package]]
+category = "dev"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
+optional = false
+python-versions = ">=2.7"
+version = "0.3"
+
+[[package]]
+category = "dev"
+description = "A platform independent file lock."
+name = "filelock"
+optional = false
+python-versions = "*"
+version = "3.0.12"
+
+[[package]]
+category = "dev"
+description = "the modular source code checker: pep8, pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.7.9"
+
+[package.dependencies]
+entrypoints = ">=0.3.0,<0.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.5.0,<2.6.0"
+pyflakes = ">=2.1.0,<2.2.0"
+
+[[package]]
+category = "dev"
+description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+name = "flake8-bugbear"
+optional = false
+python-versions = ">=3.5"
+version = "19.8.0"
+
+[package.dependencies]
+attrs = "*"
+flake8 = ">=3.0.0"
+
+[[package]]
+category = "dev"
+description = "A flake8 plugin to help you write better list/set/dict comprehensions."
+name = "flake8-comprehensions"
+optional = false
+python-versions = ">=3.5"
+version = "2.2.0"
+
+[package.dependencies]
+flake8 = "!=3.2.0"
+
+[[package]]
+category = "dev"
+description = "Flake8 and pylama plugin that checks the ordering of import statements."
+name = "flake8-import-order"
+optional = false
+python-versions = "*"
+version = "0.18.1"
+
+[package.dependencies]
+pycodestyle = "*"
+setuptools = "*"
+
+[[package]]
+category = "dev"
+description = "Flake8 extension to validate (lack of) logging format strings"
+name = "flake8-logging-format"
+optional = false
+python-versions = "*"
+version = "0.6.0"
+
+[[package]]
+category = "dev"
+description = "mutable defaults flake8 extension"
+name = "flake8-mutable"
+optional = false
+python-versions = "*"
+version = "1.2.0"
+
+[package.dependencies]
+flake8 = "*"
+
+[[package]]
+category = "dev"
+description = "Let your Python tests travel through time"
+name = "freezegun"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.3.15"
+
+[package.dependencies]
+python-dateutil = ">=1.0,<2.0 || >2.0"
+six = "*"
+
+[[package]]
+category = "dev"
+description = "File identification library for Python"
+name = "identify"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "1.4.20"
+
+[package.extras]
+license = ["editdistance"]
+
+[[package]]
+category = "dev"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.9"
+
+[[package]]
+category = "dev"
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+name = "imagesize"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.0"
+
+[[package]]
+category = "dev"
+description = "Read metadata from Python packages"
+name = "importlib-metadata"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.7.0"
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+
+[[package]]
+category = "dev"
+description = "Read resources from Python packages"
+marker = "python_version < \"3.7\""
+name = "importlib-resources"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "2.0.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
+[package.dependencies.zipp]
+python = "<3.8"
+version = ">=0.4"
+
+[package.extras]
+docs = ["sphinx", "rst.linker", "jaraco.packaging"]
+
+[[package]]
+category = "dev"
+description = "A very fast and expressive template engine."
+name = "jinja2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+category = "dev"
+description = "Jinja2 Extension for Dates and Times"
+name = "jinja2-time"
+optional = false
+python-versions = "*"
+version = "0.2.0"
+
+[package.dependencies]
+arrow = "*"
+jinja2 = "*"
+
+[[package]]
+category = "dev"
+description = "JSON Matching Expressions"
+name = "jmespath"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.0"
+
+[[package]]
+category = "dev"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
+
+[[package]]
+category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
+optional = false
+python-versions = ">=3.5"
+version = "8.4.0"
+
+[[package]]
+category = "dev"
+description = "Node.js virtual environment builder"
+name = "nodeenv"
+optional = false
+python-versions = "*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.2"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+six = "*"
+
+[[package]]
+category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+category = "dev"
+description = "A lightweight YAML Parser for Python. 🐓"
+name = "poyo"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.5.0"
+
+[[package]]
+category = "dev"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+name = "pre-commit"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.18.3"
+
+[package.dependencies]
+"aspy.yaml" = "*"
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = "*"
+nodeenv = ">=0.11.1"
+pyyaml = "*"
+six = "*"
+toml = "*"
+virtualenv = ">=15.2"
+
+[package.dependencies.importlib-resources]
+python = "<3.7"
+version = "*"
+
+[[package]]
+category = "dev"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg2-binary"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "2.8.5"
+
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.9.0"
+
+[[package]]
+category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.5.0"
+
+[[package]]
+category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.1.1"
+
+[[package]]
+category = "dev"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
+optional = false
+python-versions = ">=3.5"
+version = "2.6.1"
+
+[[package]]
+category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
+
+[[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.5"
+version = "5.4.1"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = "*"
+more-itertools = ">=4.0.0"
+packaging = "*"
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+checkqa-mypy = ["mypy (v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.10.0"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+category = "dev"
+description = "A Django plugin for pytest."
+name = "pytest-django"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.9.0"
+
+[package.dependencies]
+pytest = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["django", "django-configurations (>=2.0)", "six"]
+
+[[package]]
+category = "dev"
+description = "A py.test plugin that parses environment files before running tests"
+name = "pytest-dotenv"
+optional = false
+python-versions = "*"
+version = "0.4.0"
+
+[package.dependencies]
+pytest = ">=2.6.0"
+python-dotenv = ">=0.9.1"
+
+[[package]]
+category = "dev"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "dev"
+description = "Add .env support to your django/flask apps in development and deployments"
+name = "python-dotenv"
+optional = false
+python-versions = "*"
+version = "0.13.0"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
+category = "dev"
+description = "File type identification using libmagic"
+name = "python-magic"
+optional = false
+python-versions = "*"
+version = "0.4.15"
+
+[[package]]
+category = "dev"
+description = "A Python Slugify application that handles Unicode"
+name = "python-slugify"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
+category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2020.1"
+
+[[package]]
+category = "dev"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "5.3.1"
+
+[[package]]
+category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.6.8"
+
+[[package]]
+category = "dev"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.24.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
+category = "dev"
+description = "An Amazon S3 Transfer Manager"
+name = "s3transfer"
+optional = false
+python-versions = "*"
+version = "0.2.1"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0.0"
+
+[[package]]
+category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
+
+[[package]]
+category = "dev"
+description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+name = "snowballstemmer"
+optional = false
+python-versions = "*"
+version = "2.0.0"
+
+[[package]]
+category = "dev"
+description = "Python documentation generator"
+name = "sphinx"
+optional = false
+python-versions = ">=3.5"
+version = "3.0.3"
+
+[package.dependencies]
+Jinja2 = ">=2.3"
+Pygments = ">=2.0"
+alabaster = ">=0.7,<0.8"
+babel = ">=1.3"
+colorama = ">=0.3.5"
+docutils = ">=0.12"
+imagesize = "*"
+packaging = "*"
+requests = ">=2.5.0"
+setuptools = "*"
+snowballstemmer = ">=1.1"
+sphinxcontrib-applehelp = "*"
+sphinxcontrib-devhelp = "*"
+sphinxcontrib-htmlhelp = "*"
+sphinxcontrib-jsmath = "*"
+sphinxcontrib-qthelp = "*"
+sphinxcontrib-serializinghtml = "*"
+
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.770)", "docutils-stubs"]
+test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
+
+[[package]]
+category = "dev"
+description = "Read the Docs theme for Sphinx"
+name = "sphinx-rtd-theme"
+optional = false
+python-versions = "*"
+version = "0.4.3"
+
+[package.dependencies]
+sphinx = "*"
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+name = "sphinxcontrib-applehelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+name = "sphinxcontrib-devhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+name = "sphinxcontrib-htmlhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest", "html5lib"]
+
+[[package]]
+category = "dev"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+name = "sphinxcontrib-jsmath"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.1"
+
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
+name = "sphinxcontrib-qthelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
+name = "sphinxcontrib-serializinghtml"
+optional = false
+python-versions = ">=3.5"
+version = "1.1.4"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "main"
+description = "Non-validating SQL parser"
+name = "sqlparse"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.3.1"
+
+[[package]]
+category = "dev"
+description = "Templated project management"
+name = "temple"
+optional = false
+python-versions = "*"
+version = "1.4.5"
+
+[package.dependencies]
+click = ">=6.7"
+cookiecutter = ">=1.6.0"
+pyyaml = ">=3.12"
+requests = ">=2.13.0"
+
+[[package]]
+category = "dev"
+description = "The most basic Text::Unidecode port"
+name = "text-unidecode"
+optional = false
+python-versions = "*"
+version = "1.3"
+
+[[package]]
+category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.1"
+
+[[package]]
+category = "dev"
+description = "tox is a generic virtualenv management and test command line tool"
+name = "tox"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "3.15.2"
+
+[package.dependencies]
+colorama = ">=0.4.1"
+filelock = ">=3.0.0"
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+toml = ">=0.9.4"
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12,<2"
+
+[package.extras]
+docs = ["sphinx (>=2.0.0)", "towncrier (>=18.5.0)", "pygments-github-lexers (>=0.0.5)", "sphinxcontrib-autoprogram (>=0.1.5)"]
+testing = ["freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-xdist (>=1.22.2)", "pytest-randomly (>=1.0.0)", "flaky (>=3.4.0)", "psutil (>=5.6.1)"]
+
+[[package]]
+category = "dev"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typed-ast"
+optional = false
+python-versions = "*"
+version = "1.4.1"
+
+[[package]]
+category = "dev"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.25.9"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[[package]]
+category = "dev"
+description = "Virtual Python Environment builder"
+name = "virtualenv"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "20.0.25"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<2"
+distlib = ">=0.3.0,<1"
+filelock = ">=3.0.0,<4"
+six = ">=1.9.0,<2"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12,<2"
+
+[package.dependencies.importlib-resources]
+python = "<3.7"
+version = ">=1.0"
+
+[package.extras]
+docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
+testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-freezegun (>=0.4.1)", "flaky (>=3)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+
+[[package]]
+category = "dev"
+description = "Measures the displayed width of unicode strings in a terminal"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.2.5"
+
+[[package]]
+category = "dev"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+name = "zipp"
+optional = false
+python-versions = ">=3.6"
+version = "3.1.0"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["jaraco.itertools", "func-timeout"]
+
+[metadata]
+content-hash = "9da7db8cf241cebe347cd9e1dad7c0f218f3126141ace55dea9e072117f380db"
+python-versions = ">=3.6,<4"
+
+[metadata.files]
+alabaster = [
+    {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
+    {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+arrow = [
+    {file = "arrow-0.15.7-py2.py3-none-any.whl", hash = "sha256:61a1af3a31f731e7993509124839ac28b91b6743bd6692a949600737900cf43b"},
+    {file = "arrow-0.15.7.tar.gz", hash = "sha256:3f1a92b25bbee5f80cc8f6bdecfeade9028219229137c559c37335b4f574a292"},
+]
+asgiref = [
+    {file = "asgiref-3.2.10-py3-none-any.whl", hash = "sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed"},
+    {file = "asgiref-3.2.10.tar.gz", hash = "sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a"},
+]
+"aspy.yaml" = [
+    {file = "aspy.yaml-1.3.0-py2.py3-none-any.whl", hash = "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc"},
+    {file = "aspy.yaml-1.3.0.tar.gz", hash = "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+babel = [
+    {file = "Babel-2.8.0-py2.py3-none-any.whl", hash = "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"},
+    {file = "Babel-2.8.0.tar.gz", hash = "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38"},
+]
+binaryornot = [
+    {file = "binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"},
+    {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
+]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+]
+boto3 = [
+    {file = "boto3-1.9.243-py2.py3-none-any.whl", hash = "sha256:c6e5a7e4548ce7586c354ff633f2a66ba3c471d15a8ae6a30f873122ab04e1cf"},
+    {file = "boto3-1.9.243.tar.gz", hash = "sha256:404acbecef8f4912f18312fcfaffe7eba7f10b3b7adf7853bdba59cdf2275ebb"},
+]
+botocore = [
+    {file = "botocore-1.12.253-py2.py3-none-any.whl", hash = "sha256:dc080aed4f9b220a9e916ca29ca97a9d37e8e1d296fe89cbaeef929bf0c8066b"},
+    {file = "botocore-1.12.253.tar.gz", hash = "sha256:3baf129118575602ada9926f5166d82d02273c250d0feb313fc270944b27c48b"},
+]
+certifi = [
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+]
+cfgv = [
+    {file = "cfgv-3.0.0-py2.py3-none-any.whl", hash = "sha256:f22b426ed59cd2ab2b54ff96608d846c33dfb8766a67f0b4a6ce130ce244414f"},
+    {file = "cfgv-3.0.0.tar.gz", hash = "sha256:04b093b14ddf9fd4d17c53ebfd55582d27b76ed30050193c14e560770c5360eb"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+cookiecutter = [
+    {file = "cookiecutter-1.7.2-py2.py3-none-any.whl", hash = "sha256:430eb882d028afb6102c084bab6cf41f6559a77ce9b18dc6802e3bc0cc5f4a30"},
+    {file = "cookiecutter-1.7.2.tar.gz", hash = "sha256:efb6b2d4780feda8908a873e38f0e61778c23f6a2ea58215723bcceb5b515dac"},
+]
+coverage = [
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
+]
+distlib = [
+    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+]
+dj-database-url = [
+    {file = "dj-database-url-0.5.0.tar.gz", hash = "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163"},
+    {file = "dj_database_url-0.5.0-py2.py3-none-any.whl", hash = "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"},
+]
+django = [
+    {file = "Django-3.0.7-py3-none-any.whl", hash = "sha256:e1630333248c9b3d4e38f02093a26f1e07b271ca896d73097457996e0fae12e8"},
+    {file = "Django-3.0.7.tar.gz", hash = "sha256:5052b34b34b3425233c682e0e11d658fd6efd587d11335a0203d827224ada8f2"},
+]
+django-dynamic-fixture = [
+    {file = "django-dynamic-fixture-3.1.0.tar.gz", hash = "sha256:e772102ba40f70c2e66470cae85f3874aa992e6b22a0d0c360450f2949b0728d"},
+]
+django-timezone-field = [
+    {file = "django-timezone-field-4.0.tar.gz", hash = "sha256:7e3620fe2211c2d372fad54db8f86ff884098d018d56fda4dca5e64929e05ffc"},
+    {file = "django_timezone_field-4.0-py3-none-any.whl", hash = "sha256:758b7d41084e9ea2e89e59eb616e9b6326e6fbbf9d14b6ef062d624fe8cc6246"},
+]
+docutils = [
+    {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
+    {file = "docutils-0.15.2-py3-none-any.whl", hash = "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0"},
+    {file = "docutils-0.15.2.tar.gz", hash = "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"},
+]
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+filelock = [
+    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
+    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+]
+flake8 = [
+    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
+    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+flake8-bugbear = [
+    {file = "flake8-bugbear-19.8.0.tar.gz", hash = "sha256:d8c466ea79d5020cb20bf9f11cf349026e09517a42264f313d3f6fddb83e0571"},
+    {file = "flake8_bugbear-19.8.0-py35.py36.py37-none-any.whl", hash = "sha256:ded4d282778969b5ab5530ceba7aa1a9f1b86fa7618fc96a19a1d512331640f8"},
+]
+flake8-comprehensions = [
+    {file = "flake8-comprehensions-2.2.0.tar.gz", hash = "sha256:e36fc12bd3833e0b34fe0639b7a817d32c86238987f532078c57eafdc7a8a219"},
+    {file = "flake8_comprehensions-2.2.0-py3-none-any.whl", hash = "sha256:7b174ded3d7e73edf587e942458b6c1a7c3456d512d9c435deae367236b9562c"},
+]
+flake8-import-order = [
+    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
+    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
+]
+flake8-logging-format = [
+    {file = "flake8-logging-format-0.6.0.tar.gz", hash = "sha256:ca5f2b7fc31c3474a0aa77d227e022890f641a025f0ba664418797d979a779f8"},
+]
+flake8-mutable = [
+    {file = "flake8-mutable-1.2.0.tar.gz", hash = "sha256:ee9b77111b867d845177bbc289d87d541445ffcc6029a0c5c65865b42b18c6a6"},
+    {file = "flake8_mutable-1.2.0-py2-none-any.whl", hash = "sha256:38fd9dadcbcda6550a916197bc40ed76908119dabb37fbcca30873666c31d2d5"},
+]
+freezegun = [
+    {file = "freezegun-0.3.15-py2.py3-none-any.whl", hash = "sha256:82c757a05b7c7ca3e176bfebd7d6779fd9139c7cb4ef969c38a28d74deef89b2"},
+    {file = "freezegun-0.3.15.tar.gz", hash = "sha256:e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b"},
+]
+identify = [
+    {file = "identify-1.4.20-py2.py3-none-any.whl", hash = "sha256:acf0712ab4042642e8f44e9532d95c26fbe60c0ab8b6e5b654dd1bc6512810e0"},
+    {file = "identify-1.4.20.tar.gz", hash = "sha256:b2cd24dece806707e0b50517c1b3bcf3044e0b1cb13a72e7d34aa31c91f2a55a"},
+]
+idna = [
+    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
+    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+]
+imagesize = [
+    {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
+    {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
+    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
+]
+importlib-resources = [
+    {file = "importlib_resources-2.0.1-py2.py3-none-any.whl", hash = "sha256:83985739b3a6679702f9ab33f0ad016ad564664d0568a31ac14d7c64789453e6"},
+    {file = "importlib_resources-2.0.1.tar.gz", hash = "sha256:f5edfcece1cc9435d0979c19e08739521f4cf1aa1adaf6e571f732df6f568962"},
+]
+jinja2 = [
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+jinja2-time = [
+    {file = "jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40"},
+    {file = "jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"},
+]
+jmespath = [
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+more-itertools = [
+    {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
+    {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
+]
+nodeenv = [
+    {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
+]
+packaging = [
+    {file = "packaging-19.2-py2.py3-none-any.whl", hash = "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"},
+    {file = "packaging-19.2.tar.gz", hash = "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47"},
+]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+poyo = [
+    {file = "poyo-0.5.0-py2.py3-none-any.whl", hash = "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a"},
+    {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
+]
+pre-commit = [
+    {file = "pre_commit-1.18.3-py2.py3-none-any.whl", hash = "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"},
+    {file = "pre_commit-1.18.3.tar.gz", hash = "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f"},
+]
+psycopg2-binary = [
+    {file = "psycopg2-binary-2.8.5.tar.gz", hash = "sha256:ccdc6a87f32b491129ada4b87a43b1895cf2c20fdb7f98ad979647506ffc41b6"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:96d3038f5bd061401996614f65d27a4ecb62d843eb4f48e212e6d129171a721f"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:08507efbe532029adee21b8d4c999170a83760d38249936038bd0602327029b5"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:b9a8b391c2b0321e0cd7ec6b4cfcc3dd6349347bd1207d48bcb752aa6c553a66"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27m-win32.whl", hash = "sha256:3286541b9d85a340ee4ed42732d15fc1bb441dc500c97243a768154ab8505bb5"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27m-win_amd64.whl", hash = "sha256:008da3ab51adc70a5f1cfbbe5db3a22607ab030eb44bcecf517ad11a0c2b3cac"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ba13346ff6d3eb2dca0b6fa0d8a9d999eff3dcd9b55f3a890f12b0b6362b2b38"},
+    {file = "psycopg2_binary-2.8.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:c8830b7d5f16fd79d39b21e3d94f247219036b29b30c8270314c46bf8b732389"},
+    {file = "psycopg2_binary-2.8.5-cp34-cp34m-win32.whl", hash = "sha256:51f7823f1b087d2020d8e8c9e6687473d3d239ba9afc162d9b2ab6e80b53f9f9"},
+    {file = "psycopg2_binary-2.8.5-cp34-cp34m-win_amd64.whl", hash = "sha256:107d9be3b614e52a192719c6bf32e8813030020ea1d1215daa86ded9a24d8b04"},
+    {file = "psycopg2_binary-2.8.5-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:930315ac53dc65cbf52ab6b6d27422611f5fb461d763c531db229c7e1af6c0b3"},
+    {file = "psycopg2_binary-2.8.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:6bb2dd006a46a4a4ce95201f836194eb6a1e863f69ee5bab506673e0ca767057"},
+    {file = "psycopg2_binary-2.8.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3939cf75fc89c5e9ed836e228c4a63604dff95ad19aed2bbf71d5d04c15ed5ce"},
+    {file = "psycopg2_binary-2.8.5-cp35-cp35m-win32.whl", hash = "sha256:a20299ee0ea2f9cca494396ac472d6e636745652a64a418b39522c120fd0a0a4"},
+    {file = "psycopg2_binary-2.8.5-cp35-cp35m-win_amd64.whl", hash = "sha256:cc30cb900f42c8a246e2cb76539d9726f407330bc244ca7729c41a44e8d807fb"},
+    {file = "psycopg2_binary-2.8.5-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:40abc319f7f26c042a11658bf3dd3b0b3bceccf883ec1c565d5c909a90204434"},
+    {file = "psycopg2_binary-2.8.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:702f09d8f77dc4794651f650828791af82f7c2efd8c91ae79e3d9fe4bb7d4c98"},
+    {file = "psycopg2_binary-2.8.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d1a8b01f6a964fec702d6b6dac1f91f2b9f9fe41b310cbb16c7ef1fac82df06d"},
+    {file = "psycopg2_binary-2.8.5-cp36-cp36m-win32.whl", hash = "sha256:17a0ea0b0eabf07035e5e0d520dabc7950aeb15a17c6d36128ba99b2721b25b1"},
+    {file = "psycopg2_binary-2.8.5-cp36-cp36m-win_amd64.whl", hash = "sha256:e004db88e5a75e5fdab1620fb9f90c9598c2a195a594225ac4ed2a6f1c23e162"},
+    {file = "psycopg2_binary-2.8.5-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:a34826d6465c2e2bbe9d0605f944f19d2480589f89863ed5f091943be27c9de4"},
+    {file = "psycopg2_binary-2.8.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cac918cd7c4c498a60f5d2a61d4f0a6091c2c9490d81bc805c963444032d0dab"},
+    {file = "psycopg2_binary-2.8.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7b832d76cc65c092abd9505cc670c4e3421fd136fb6ea5b94efbe4c146572505"},
+    {file = "psycopg2_binary-2.8.5-cp37-cp37m-win32.whl", hash = "sha256:bb0608694a91db1e230b4a314e8ed00ad07ed0c518f9a69b83af2717e31291a3"},
+    {file = "psycopg2_binary-2.8.5-cp37-cp37m-win_amd64.whl", hash = "sha256:eb2f43ae3037f1ef5e19339c41cf56947021ac892f668765cd65f8ab9814192e"},
+    {file = "psycopg2_binary-2.8.5-cp38-cp38-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:07cf82c870ec2d2ce94d18e70c13323c89f2f2a2628cbf1feee700630be2519a"},
+    {file = "psycopg2_binary-2.8.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a69970ee896e21db4c57e398646af9edc71c003bc52a3cc77fb150240fefd266"},
+    {file = "psycopg2_binary-2.8.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7036ccf715925251fac969f4da9ad37e4b7e211b1e920860148a10c0de963522"},
+    {file = "psycopg2_binary-2.8.5-cp38-cp38-win32.whl", hash = "sha256:8f74e631b67482d504d7e9cf364071fc5d54c28e79a093ff402d5f8f81e23bfa"},
+    {file = "psycopg2_binary-2.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:fa466306fcf6b39b8a61d003123d442b23707d635a5cb05ac4e1b62cc79105cd"},
+]
+py = [
+    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
+    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
+    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+]
+pyflakes = [
+    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
+    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+]
+pygments = [
+    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
+    {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-5.4.1-py3-none-any.whl", hash = "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172"},
+    {file = "pytest-5.4.1.tar.gz", hash = "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.10.0.tar.gz", hash = "sha256:1a629dc9f48e53512fcbfda6b07de490c374b0c83c55ff7a1720b3fccff0ac87"},
+    {file = "pytest_cov-2.10.0-py2.py3-none-any.whl", hash = "sha256:6e6d18092dce6fad667cd7020deed816f858ad3b49d5b5e2b1cc1c97a4dba65c"},
+]
+pytest-django = [
+    {file = "pytest-django-3.9.0.tar.gz", hash = "sha256:664e5f42242e5e182519388f01b9f25d824a9feb7cd17d8f863c8d776f38baf9"},
+    {file = "pytest_django-3.9.0-py2.py3-none-any.whl", hash = "sha256:64f99d565dd9497af412fcab2989fe40982c1282d4118ff422b407f3f7275ca5"},
+]
+pytest-dotenv = [
+    {file = "pytest-dotenv-0.4.0.tar.gz", hash = "sha256:a3a0adf9e17cf7c9e38ec597a74cc902ac76baa1cc5a9bd7581a3711930ad057"},
+    {file = "pytest_dotenv-0.4.0-py3-none-any.whl", hash = "sha256:12ff70de238cdc2c8d838ef92b720325ceb6ae2c9967be5f4e606a36de48345c"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.13.0.tar.gz", hash = "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"},
+    {file = "python_dotenv-0.13.0-py2.py3-none-any.whl", hash = "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7"},
+]
+python-magic = [
+    {file = "python-magic-0.4.15.tar.gz", hash = "sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"},
+    {file = "python_magic-0.4.15-py2.py3-none-any.whl", hash = "sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375"},
+]
+python-slugify = [
+    {file = "python-slugify-4.0.0.tar.gz", hash = "sha256:a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c"},
+]
+pytz = [
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+]
+pyyaml = [
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+]
+regex = [
+    {file = "regex-2020.6.8-cp27-cp27m-win32.whl", hash = "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"},
+    {file = "regex-2020.6.8-cp27-cp27m-win_amd64.whl", hash = "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded"},
+    {file = "regex-2020.6.8-cp36-cp36m-win32.whl", hash = "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3"},
+    {file = "regex-2020.6.8-cp36-cp36m-win_amd64.whl", hash = "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3"},
+    {file = "regex-2020.6.8-cp37-cp37m-win32.whl", hash = "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9"},
+    {file = "regex-2020.6.8-cp37-cp37m-win_amd64.whl", hash = "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux1_i686.whl", hash = "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf"},
+    {file = "regex-2020.6.8-cp38-cp38-win32.whl", hash = "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754"},
+    {file = "regex-2020.6.8-cp38-cp38-win_amd64.whl", hash = "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5"},
+    {file = "regex-2020.6.8.tar.gz", hash = "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac"},
+]
+requests = [
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
+s3transfer = [
+    {file = "s3transfer-0.2.1-py2.py3-none-any.whl", hash = "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"},
+    {file = "s3transfer-0.2.1.tar.gz", hash = "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
+    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+]
+sphinx = [
+    {file = "Sphinx-3.0.3-py3-none-any.whl", hash = "sha256:f5505d74cf9592f3b997380f9bdb2d2d0320ed74dd69691e3ee0644b956b8d83"},
+    {file = "Sphinx-3.0.3.tar.gz", hash = "sha256:62edfd92d955b868d6c124c0942eba966d54b5f3dcb4ded39e65f74abac3f572"},
+]
+sphinx-rtd-theme = [
+    {file = "sphinx_rtd_theme-0.4.3-py2.py3-none-any.whl", hash = "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4"},
+    {file = "sphinx_rtd_theme-0.4.3.tar.gz", hash = "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"},
+]
+sphinxcontrib-applehelp = [
+    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
+    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
+]
+sphinxcontrib-devhelp = [
+    {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
+    {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
+]
+sphinxcontrib-htmlhelp = [
+    {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},
+    {file = "sphinxcontrib_htmlhelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f"},
+]
+sphinxcontrib-jsmath = [
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+]
+sphinxcontrib-qthelp = [
+    {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
+    {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
+]
+sphinxcontrib-serializinghtml = [
+    {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
+    {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
+]
+sqlparse = [
+    {file = "sqlparse-0.3.1-py2.py3-none-any.whl", hash = "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e"},
+    {file = "sqlparse-0.3.1.tar.gz", hash = "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"},
+]
+temple = [
+    {file = "temple-1.4.5-py3-none-any.whl", hash = "sha256:f912f310fe2533cc9622c48b7c28f1f5cb65686873959398d4d4a253b367ad7a"},
+    {file = "temple-1.4.5.tar.gz", hash = "sha256:e7d4e5d6bc601a2f587dde626577d86f14e19c06caddc38cdab0b3b064cd2d75"},
+]
+text-unidecode = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+toml = [
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+]
+tox = [
+    {file = "tox-3.15.2-py2.py3-none-any.whl", hash = "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e"},
+    {file = "tox-3.15.2.tar.gz", hash = "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+]
+virtualenv = [
+    {file = "virtualenv-20.0.25-py2.py3-none-any.whl", hash = "sha256:ffffcb3c78a671bb3d590ac3bc67c081ea2188befeeb058870cba13e7f82911b"},
+    {file = "virtualenv-20.0.25.tar.gz", hash = "sha256:f332ba0b2dfbac9f6b1da9f11224f0036b05cdb4df23b228527c2a2d5504aeed"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+zipp = [
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 version = "0.0.0"
 description = "Native postgres bulk update and upsert operations."
-authors = ["Jyve Engineering"]
+authors = ["Wes Kendall"]
 classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
@@ -59,3 +59,6 @@ Sphinx = "=3.0.3"
 sphinx-rtd-theme = "=0.4.3"
 temple = "*"
 tox = "=3.15.2"
+django-timezone-field = "^4.0"
+django-dynamic-fixture = "^3.1.0"
+freezegun = "^0.3.15"


### PR DESCRIPTION
The initial release of django-pgbulk includes three functions for
bulk operations in postgres:

1. ``pgbulk.update`` - For updating a list of models in bulk. Although Django
   provides a ``bulk_update`` in 2.2, it performs individual updates for
   every row and does not perform a native bulk update.
2. ``pgbulk.upsert`` - For doing a bulk update or insert. This function uses
   postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
   operation. There are several options to this function that allow the
   user to avoid touching rows if they result in a duplicate update, along
   with returning which rows were updated, created, or untouched.
3. ``pgbulk.sync`` - For syncing a list of models with a table. Does a bulk
   upsert and also deletes any rows in the source queryset that were not
   part of the input data.

Type: api-break